### PR TITLE
🛺  認証

### DIFF
--- a/front/firebase/seeds/firestore/users.json
+++ b/front/firebase/seeds/firestore/users.json
@@ -2,6 +2,8 @@
   "users": {
     "C5Ja2gXGLeIXTjhWZbDiWUWe8Whd": {
       "name": "テストゆーざ",
+      "icon": null,
+      "userId": "ma_ma_hima",
       "subCollection": {
         "users/C5Ja2gXGLeIXTjhWZbDiWUWe8Whd/joinTrips": {
           "1": {

--- a/front/firebase/seeds/firestore/users.json
+++ b/front/firebase/seeds/firestore/users.json
@@ -4,6 +4,7 @@
       "name": "テストゆーざ",
       "icon": null,
       "userId": "ma_ma_hima",
+      "email": "test@example.com",
       "subCollection": {
         "users/C5Ja2gXGLeIXTjhWZbDiWUWe8Whd/joinTrips": {
           "1": {

--- a/front/firebase/utils/createTestUserIfNotExsists.ts
+++ b/front/firebase/utils/createTestUserIfNotExsists.ts
@@ -5,7 +5,7 @@ import { TestUserType } from '@/utils/type'
 
 export const createTestUserIfNotExsists = async () => {
   const users = await admin.auth().listUsers()
-  if (!users.users.find(item => item.email === 'test@example.com')) {
+  if (!users.users.find((item) => item.email === 'test@example.com')) {
     const testUser = readJson<TestUserType>(
       path.join(process.cwd(), 'firebase/seeds/auth/test-user.json')
     )

--- a/front/firebase/utils/createTestUserIfNotExsists.ts
+++ b/front/firebase/utils/createTestUserIfNotExsists.ts
@@ -4,8 +4,8 @@ import { readJson } from '@/utils/readJson'
 import { TestUserType } from '@/utils/type'
 
 export const createTestUserIfNotExsists = async () => {
-  const users = await admin.auth().listUsers(1)
-  if (!users.users.length) {
+  const users = await admin.auth().listUsers()
+  if (!users.users.find(item => item.email === 'test@example.com')) {
     const testUser = readJson<TestUserType>(
       path.join(process.cwd(), 'firebase/seeds/auth/test-user.json')
     )

--- a/front/src/components/Auths/CheckAuth.tsx
+++ b/front/src/components/Auths/CheckAuth.tsx
@@ -8,14 +8,14 @@ type CheckAuthProps = {
 
 export const CheckAuth = ({ children }: CheckAuthProps) => {
   const currentUserUid = useAppSelector(authSelectors.currentUserUid)
-  const currentUserData = useAppSelector(currentUserSelectors.currentUserData)
+  const isRegisteredUser = useAppSelector(currentUserSelectors.isRegisteredUser)
 
   const { isCurrentPageStatic, isCurrentPageRequireUserRegistration } =
     useCheckAuth()
 
   const isReady =
     isCurrentPageStatic ||
-    (currentUserData && currentUserUid) ||
+    (isRegisteredUser && currentUserUid) ||
     !isCurrentPageRequireUserRegistration
 
   return <div>{isReady ? <div>{children}</div> : <>ローディング</>}</div>

--- a/front/src/components/Auths/CheckAuth.tsx
+++ b/front/src/components/Auths/CheckAuth.tsx
@@ -1,13 +1,22 @@
 import { useCheckAuth } from '@/hooks/auths'
+import { useAppSelector } from '@/redux/rootStore'
+import { authSelectors, currentUserSelectors } from '@/redux/stores'
 
 type CheckAuthProps = {
   children: React.ReactNode
 }
 
 export const CheckAuth = ({ children }: CheckAuthProps) => {
-  const { isSignIn } = useCheckAuth()
+  const currentUserUid = useAppSelector(authSelectors.currentUserUid)
+  const currentUserData = useAppSelector(currentUserSelectors.currentUserData)
 
-  return (
-    <div>{isSignIn ? <div>{children}</div> : <div>ローディング中</div>}</div>
-  )
+  const { isCurrentPageStatic, isCurrentPageRequireUserRegistration } =
+    useCheckAuth()
+
+  const isReady =
+    isCurrentPageStatic ||
+    (currentUserData && currentUserUid) ||
+    !isCurrentPageRequireUserRegistration
+
+  return <div>{isReady ? <div>{children}</div> : <>ローディング</>}</div>
 }

--- a/front/src/components/Headers/Header.tsx
+++ b/front/src/components/Headers/Header.tsx
@@ -4,7 +4,7 @@ import { Container } from '@/components/Containers'
 import { styles } from '@/styles/components/Headers/Header.styles'
 
 type HeaderProps = {
-  href: `/${string}`
+  href?: `/${string}`
   title?: string
 }
 
@@ -12,9 +12,11 @@ export const Header = ({ title, href }: HeaderProps) => {
   return (
     <header css={styles.header}>
       <Container bgColor="none">
-        <Link css={styles.iconWrapper} href={href}>
-          <HiOutlineChevronLeft size={24} />
-        </Link>
+        {href && (
+          <Link css={styles.iconWrapper} href={href}>
+            <HiOutlineChevronLeft size={24} />
+          </Link>
+        )}
         {title && <h1 css={styles.title}>{title}</h1>}
       </Container>
     </header>

--- a/front/src/components/Navigations/NavigationBottom.tsx
+++ b/front/src/components/Navigations/NavigationBottom.tsx
@@ -8,11 +8,14 @@ import {
   HiGlobe,
   HiUser
 } from 'react-icons/hi'
+import { useAppSelector } from '@/redux/rootStore'
+import { currentUserSelectors } from '@/redux/stores'
 import { styles } from '@/styles/components/Navigations/NavigationBottom.styles'
 
 export const NavigationBottom = () => {
   const router = useRouter()
   const currentPath = router.pathname
+  const currentUserData = useAppSelector(currentUserSelectors.currentUserData)
 
   return (
     <nav css={styles.wrapper}>
@@ -45,10 +48,10 @@ export const NavigationBottom = () => {
         </li>
         <li css={styles.nav}>
           <Link
-            css={[styles.navItem, currentPath === '/mypage' && styles.focus]}
-            href="mypage"
+            css={[styles.navItem, currentPath === '/[userId]' && styles.focus]}
+            href={currentUserData.userId}
           >
-            {currentPath === '/mypage' ? (
+            {currentPath === '/[userId]' ? (
               <HiUser size={24} />
             ) : (
               <HiOutlineUser size={24} />

--- a/front/src/hooks/auths/index.ts
+++ b/front/src/hooks/auths/index.ts
@@ -1,1 +1,2 @@
 export { useCheckAuth } from '@/hooks/auths/useCheckAuth'
+export { useSignIn } from '@/hooks/auths/useSignIn'

--- a/front/src/hooks/auths/index.ts
+++ b/front/src/hooks/auths/index.ts
@@ -1,2 +1,3 @@
 export { useCheckAuth } from '@/hooks/auths/useCheckAuth'
 export { useSignIn } from '@/hooks/auths/useSignIn'
+export { useSignOut } from '@/hooks/auths/useSignOut'

--- a/front/src/hooks/auths/useCheckAuth.ts
+++ b/front/src/hooks/auths/useCheckAuth.ts
@@ -1,32 +1,83 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useRouter } from 'next/router'
-import { useAppDispath } from '@/redux/rootStore'
-import { setUser } from '@/redux/stores'
+import { auth } from '@/lib/firebase'
+import { useAppDispath, useAppSelector } from '@/redux/rootStore'
+import { usersApi } from '@/redux/services/firestore'
+import { authSelectors, setUser } from '@/redux/stores'
+import { onAuthStateChanged } from '@/utils/firebase'
 
 export const useCheckAuth = () => {
   const router = useRouter()
   const dispatch = useAppDispath()
-  const [isSignIn, setIsSignIn] = useState(false)
 
-  const checkAuth = () => {
+  const currentUserUid = useAppSelector(authSelectors.currentUserUid)
+
+  // TODO: roleの実装
+  const staticPages = ['/404', '/auth']
+  const signInRequiredPages = [
+    '/home',
+    '/notifications',
+    '/settings',
+    '/triplate/new',
+    '/triplink'
+  ]
+
+  const isCurrentPageStatic = staticPages.includes(router.pathname)
+  const isCurrentPageRequireUserRegistration = signInRequiredPages.includes(
+    router.pathname
+  )
+
+  const checkAuth = async () => {
     try {
-      dispatch(
-        setUser({
-          uid: 'C5Ja2gXGLeIXTjhWZbDiWUWe8Whd'
-        })
-      )
-      setIsSignIn(true)
+      const user = await onAuthStateChanged(auth)
+
+      // ログイン中
+      if (user) {
+        dispatch(
+          setUser({
+            uid: user.uid
+          })
+        )
+
+        // ユーザ登録済みか確認する
+        const { data } = await dispatch(
+          usersApi.endpoints.getUser.initiate(user.uid)
+        )
+        const isRegisteredUser = !!data?.userId || false
+
+        // 認証済みで，ユーザ未登録の場合はトップページにリダイレクト
+        if (isCurrentPageRequireUserRegistration && !isRegisteredUser) {
+          router.push('/')
+          return
+        }
+
+        // ログアウト or 未認証ユーザ
+      } else {
+        dispatch(
+          setUser({
+            uid: null
+          })
+        )
+        // ユーザ登録必須ページにいる場合はトップページにリダイレクト
+        if (isCurrentPageRequireUserRegistration) {
+          router.push('/')
+          return
+        }
+      }
     } catch (e) {
       console.error(e)
-      setIsSignIn(false)
     }
   }
 
   useEffect(() => {
+    // ログインなしてアクセス可能なページには認証確認しない
+    if (isCurrentPageStatic) return
+
     checkAuth()
-  }, [router.pathname])
+  }, [router.pathname, currentUserUid])
 
   return {
-    isSignIn
+    isCurrentPageStatic,
+    isCurrentPageRequireUserRegistration
   }
 }

--- a/front/src/hooks/auths/useCheckAuth.ts
+++ b/front/src/hooks/auths/useCheckAuth.ts
@@ -22,9 +22,11 @@ export const useCheckAuth = () => {
     '/triplink'
   ]
 
-  const isCurrentPageStatic = staticPages.includes(router.pathname)
-  const isCurrentPageRequireUserRegistration = signInRequiredPages.includes(
-    router.pathname
+  const isCurrentPageStatic = staticPages.some((page) =>
+    router.pathname.startsWith(page)
+  )
+  const isCurrentPageRequireUserRegistration = signInRequiredPages.some(
+    (page) => router.pathname.startsWith(page)
   )
 
   const checkAuth = async () => {

--- a/front/src/hooks/auths/useCheckAuth.ts
+++ b/front/src/hooks/auths/useCheckAuth.ts
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import { auth } from '@/lib/firebase'
 import { useAppDispath, useAppSelector } from '@/redux/rootStore'
 import { usersApi } from '@/redux/services/firestore'
-import { authSelectors, currentUserSelectors, setUser } from '@/redux/stores'
+import { authSelectors, setUser } from '@/redux/stores'
 import { onAuthStateChanged } from '@/utils/firebase'
 
 export const useCheckAuth = () => {
@@ -11,7 +11,6 @@ export const useCheckAuth = () => {
   const dispatch = useAppDispath()
 
   const currentUserUid = useAppSelector(authSelectors.currentUserUid)
-  const isRegisteredUser = useAppSelector(currentUserSelectors.isRegisteredUser)
 
   // TODO: roleの実装
   const staticPages = ['/404', '/auth']
@@ -46,9 +45,15 @@ export const useCheckAuth = () => {
         )
         const isRegisteredUser = !!data?.userId || false
 
-        // 認証済みで，ユーザ未登録の場合はトップページにリダイレクト
+        // 認証必要ページは，ユーザ未登録の場合はトップにリダイレクト
         if (isCurrentPageRequireUserRegistration && !isRegisteredUser) {
           router.push('/')
+          return
+        }
+
+        // ユーザ登録済みで/user/newにアクセスした場合
+        if (isRegisteredUser && router.pathname === '/user/new') {
+          router.push('/home')
           return
         }
 
@@ -73,10 +78,6 @@ export const useCheckAuth = () => {
   useEffect(() => {
     // ログインなしてアクセス可能なページには認証確認しない
     if (isCurrentPageStatic) return
-    // 登録済みユーザはユーザ登録画面にアクセスすると/homeにリダイレクト
-    if (isRegisteredUser && router.pathname === '/user/new') {
-      router.push('/home')
-    }
 
     checkAuth()
   }, [router.pathname, currentUserUid])

--- a/front/src/hooks/auths/useCheckAuth.ts
+++ b/front/src/hooks/auths/useCheckAuth.ts
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import { auth } from '@/lib/firebase'
 import { useAppDispath, useAppSelector } from '@/redux/rootStore'
 import { usersApi } from '@/redux/services/firestore'
-import { authSelectors, setUser } from '@/redux/stores'
+import { authSelectors, currentUserSelectors, setUser } from '@/redux/stores'
 import { onAuthStateChanged } from '@/utils/firebase'
 
 export const useCheckAuth = () => {
@@ -11,6 +11,7 @@ export const useCheckAuth = () => {
   const dispatch = useAppDispath()
 
   const currentUserUid = useAppSelector(authSelectors.currentUserUid)
+  const isRegisteredUser = useAppSelector(currentUserSelectors.isRegisteredUser)
 
   // TODO: roleの実装
   const staticPages = ['/404', '/auth']
@@ -72,6 +73,10 @@ export const useCheckAuth = () => {
   useEffect(() => {
     // ログインなしてアクセス可能なページには認証確認しない
     if (isCurrentPageStatic) return
+    // 登録済みユーザはユーザ登録画面にアクセスすると/homeにリダイレクト
+    if (isRegisteredUser && router.pathname === '/user/new') {
+      router.push('/home')
+    }
 
     checkAuth()
   }, [router.pathname, currentUserUid])

--- a/front/src/hooks/auths/useSignIn.ts
+++ b/front/src/hooks/auths/useSignIn.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import {
+  GoogleAuthProvider,
+  getRedirectResult,
+  signInWithRedirect
+} from 'firebase/auth'
+import { auth } from '@/lib/firebase'
+
+const validRedirectPages = ['/user/new']
+
+export const useSignIn = () => {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return
+    }
+
+    ;(async () => {
+      const result = await getRedirectResult(auth)
+      const { redirectUri } = router.query
+
+      // 適切なリダイレクト先が設定されていない場合は認証しない
+      if (!validRedirectPages.includes(String(redirectUri))) {
+        router.push('/')
+        return
+      }
+
+      if (!result) {
+        try {
+          await signInWithRedirect(auth, new GoogleAuthProvider())
+        } catch (e) {
+          router.push('/')
+        }
+      } else {
+        const { redirectUri } = router.query
+
+        // 任意のページにリダイレクトできないように検証する（オープンリダイレクト対策）
+        // https://qiita.com/tamura__246/items/f41d2f69f1c8494493e0
+        if (redirectUri === '/user/new') {
+          router.push('/user/new')
+        } else {
+          router.push('/')
+        }
+      }
+    })()
+  }, [router.isReady])
+}

--- a/front/src/hooks/auths/useSignIn.ts
+++ b/front/src/hooks/auths/useSignIn.ts
@@ -12,38 +12,40 @@ const validRedirectPages = ['/user/new']
 export const useSignIn = () => {
   const router = useRouter()
 
+  const signInHandler = async () => {
+    const result = await getRedirectResult(auth)
+    const { redirectUri } = router.query
+
+    // 適切なリダイレクト先が設定されていない場合は認証しない
+    if (!validRedirectPages.includes(String(redirectUri))) {
+      router.push('/')
+      return
+    }
+
+    if (!result) {
+      try {
+        await signInWithRedirect(auth, new GoogleAuthProvider())
+      } catch (e) {
+        router.push('/')
+      }
+    } else {
+      const { redirectUri } = router.query
+
+      // 任意のページにリダイレクトできないように検証する（オープンリダイレクト対策）
+      // https://qiita.com/tamura__246/items/f41d2f69f1c8494493e0
+      if (redirectUri === '/user/new') {
+        router.push('/user/new')
+      } else {
+        router.push('/')
+      }
+    }
+  }
+
   useEffect(() => {
     if (!router.isReady) {
       return
     }
 
-    ;(async () => {
-      const result = await getRedirectResult(auth)
-      const { redirectUri } = router.query
-
-      // 適切なリダイレクト先が設定されていない場合は認証しない
-      if (!validRedirectPages.includes(String(redirectUri))) {
-        router.push('/')
-        return
-      }
-
-      if (!result) {
-        try {
-          await signInWithRedirect(auth, new GoogleAuthProvider())
-        } catch (e) {
-          router.push('/')
-        }
-      } else {
-        const { redirectUri } = router.query
-
-        // 任意のページにリダイレクトできないように検証する（オープンリダイレクト対策）
-        // https://qiita.com/tamura__246/items/f41d2f69f1c8494493e0
-        if (redirectUri === '/user/new') {
-          router.push('/user/new')
-        } else {
-          router.push('/')
-        }
-      }
-    })()
+    signInHandler()
   }, [router.isReady])
 }

--- a/front/src/hooks/auths/useSignOut.ts
+++ b/front/src/hooks/auths/useSignOut.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { auth } from '@/lib/firebase'
+import { clearAll } from '@/redux/actions'
+import { useAppDispath } from '@/redux/rootStore'
+
+export const useSignOut = () => {
+  const router = useRouter()
+  const dispatch = useAppDispath()
+  const [disabled, setDisabled] = useState(false)
+
+  const signOutHandler = async () => {
+    setDisabled(true)
+    try {
+      if (!auth.currentUser) {
+        setDisabled(false)
+        return
+      }
+
+      await auth.signOut()
+
+      dispatch(clearAll())
+
+      setDisabled(false)
+      router.push('/')
+    } catch (e) {
+      // TODO: エラーハンドリング
+      console.error(e)
+      setDisabled(false)
+    }
+  }
+
+  return { signOutHandler, disabled }
+}

--- a/front/src/pages/[userId]/index.tsx
+++ b/front/src/pages/[userId]/index.tsx
@@ -5,6 +5,8 @@ import { HiOutlineBell, HiOutlineCog } from 'react-icons/hi'
 import { Avatar } from '@/components/Avatars'
 import { Container } from '@/components/Containers'
 import { NavigationBottom } from '@/components/Navigations'
+import { useAppSelector } from '@/redux/rootStore'
+import { currentUserSelectors } from '@/redux/stores'
 import { styles } from '@/styles/pages/[userId]/index.styles'
 
 const Mypage = () => {
@@ -12,12 +14,8 @@ const Mypage = () => {
   const { userId } = router.query
   const triplateId = '123'
 
-  // example
-  const user = {
-    name: 'おぱんちゅうさぎ',
-    url: '/images/user_sample.jpeg',
-    description: 'ゆるーい旅行ログです'
-  }
+  // TODO: userIdからGETさせる （今は認証ユーザのデータを表示させてるだけ）
+  const user = useAppSelector(currentUserSelectors.currentUserData)
 
   return (
     <>
@@ -38,9 +36,8 @@ const Mypage = () => {
         <div css={styles.wrapper}>
           <div css={styles.content}>
             <div css={styles.user}>
-              <Avatar size="lg" url={user.url} />
+              <Avatar size="lg" url={user.icon || ''} />
               <h1>{user.name}</h1>
-              <p>{user.description}</p>
               <Link href={`/settings/profile?prev=${userId}`}>
                 <HiOutlineCog size={15} />
                 プロフィール設定

--- a/front/src/pages/auth.tsx
+++ b/front/src/pages/auth.tsx
@@ -1,0 +1,9 @@
+import { useSignIn } from '@/hooks/auths'
+
+const AuthRedirectPage = () => {
+  useSignIn()
+
+  return <>ローディング</>
+}
+
+export default AuthRedirectPage

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -1,25 +1,32 @@
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { HiOutlineQrcode } from 'react-icons/hi'
+import { ButtonFill } from '@/components/Buttons'
 import { ButtonIconWIthTextHorizontal } from '@/components/Buttons/ButtonIconWithTextHorizontal'
 import { Container } from '@/components/Containers'
 import { Header } from '@/components/Headers'
 import { ModalMember } from '@/components/Modals'
 import { useDisclosure } from '@/hooks/modals'
-import { useAppSelector } from '@/redux/rootStore'
-import { authSelectors } from '@/redux/stores'
 
 const Index = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure()
+  const router = useRouter()
 
-  // 確認よう
-  const currentUser = useAppSelector(authSelectors.currentUser)
+  const { isOpen, onOpen, onClose } = useDisclosure()
 
   return (
     <>
       <Header href="/" title="GoogleMapから追加" />
       <Container bgColor="blue">
+        <div>
+          <ButtonFill
+            onClick={() => {
+              router.push('/auth?redirectUri=/user/new')
+            }}
+          >
+            ログイン
+          </ButtonFill>
+        </div>
         <div>動作確認なう</div>
-        <h1>{currentUser.uid}</h1>
         <div>
           <Link href="/home">/home</Link>
         </div>

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { signInWithEmailAndPassword } from 'firebase/auth'
 import { HiOutlineQrcode } from 'react-icons/hi'
 import { ButtonFill } from '@/components/Buttons'
 import { ButtonIconWIthTextHorizontal } from '@/components/Buttons/ButtonIconWithTextHorizontal'
@@ -8,6 +9,7 @@ import { Header } from '@/components/Headers'
 import { ModalMember } from '@/components/Modals'
 import { useSignOut } from '@/hooks/auths'
 import { useDisclosure } from '@/hooks/modals'
+import { auth } from '@/lib/firebase'
 import { useAppSelector } from '@/redux/rootStore'
 import { currentUserSelectors } from '@/redux/stores'
 
@@ -17,6 +19,12 @@ const Index = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { signOutHandler } = useSignOut()
   const currentUser = useAppSelector(currentUserSelectors.currentUserData)
+
+  // 仮置き
+  const signInTestUser = async () => {
+    await signInWithEmailAndPassword(auth, 'test@example.com', 'password')
+    router.push('/home')
+  }
 
   return (
     <>
@@ -54,6 +62,12 @@ const Index = () => {
         title="aaaa"
         onClick={onOpen}
       />
+
+      {process.env.NODE_ENV === 'development' && (
+        <ButtonFill onClick={signInTestUser}>
+          テストユーザでログイン（シードデータ）
+        </ButtonFill>
+      )}
       <ModalMember isOpen={isOpen} onClose={onClose} />
     </>
   )

--- a/front/src/pages/index.tsx
+++ b/front/src/pages/index.tsx
@@ -6,25 +6,37 @@ import { ButtonIconWIthTextHorizontal } from '@/components/Buttons/ButtonIconWit
 import { Container } from '@/components/Containers'
 import { Header } from '@/components/Headers'
 import { ModalMember } from '@/components/Modals'
+import { useSignOut } from '@/hooks/auths'
 import { useDisclosure } from '@/hooks/modals'
+import { useAppSelector } from '@/redux/rootStore'
+import { currentUserSelectors } from '@/redux/stores'
 
 const Index = () => {
   const router = useRouter()
 
   const { isOpen, onOpen, onClose } = useDisclosure()
+  const { signOutHandler } = useSignOut()
+  const currentUser = useAppSelector(currentUserSelectors.currentUserData)
 
   return (
     <>
       <Header href="/" title="GoogleMapから追加" />
       <Container bgColor="blue">
         <div>
+          <ul>
+            <li>name: {currentUser.name}</li>
+            <li>userId: {currentUser.userId}</li>
+          </ul>
+        </div>
+        <div>
           <ButtonFill
             onClick={() => {
               router.push('/auth?redirectUri=/user/new')
             }}
           >
-            ログイン
+            サインイン
           </ButtonFill>
+          <ButtonFill onClick={signOutHandler}>サインアウト</ButtonFill>
         </div>
         <div>動作確認なう</div>
         <div>

--- a/front/src/pages/user/new.tsx
+++ b/front/src/pages/user/new.tsx
@@ -1,17 +1,77 @@
+import { useState } from 'react'
 import { useRouter } from 'next/router'
 import { ButtonFill } from '@/components/Buttons'
 import { Header } from '@/components/Headers'
+import { auth } from '@/lib/firebase'
+import { useAppSelector } from '@/redux/rootStore'
+import { useCreateUserMutation } from '@/redux/services/firestore'
+import { authSelectors } from '@/redux/stores'
+import { onAuthStateChanged } from '@/utils/firebase/onAuthStateChanged'
 
 const UserNew = () => {
   const router = useRouter()
+  const currentUserUid = useAppSelector(authSelectors.currentUserUid)
+
+  // TODO 仮置き ユーザ登録フローの確認のため
+  const [disabled, setDisabled] = useState(false)
+  const [createUser] = useCreateUserMutation()
+
+  const onCreateUserHandler = async () => {
+    setDisabled(true)
+    try {
+      const user = await onAuthStateChanged(auth)
+      // この辺もcreateuserフォーム作る時に直す
+      if (!user) return
+      if (user.providerData[0].providerId !== 'google.com') return
+      if (!user.email) return
+
+      await createUser({
+        id: user.uid,
+        body: {
+          email: user.email,
+          icon: user.photoURL,
+          name: user.displayName || '',
+          userId: user.uid.substring(1, 5),
+          description: '',
+          links: {
+            instagram: null,
+            twitter: null
+          }
+        }
+      }).unwrap()
+      setDisabled(false)
+    } catch (e) {
+      setDisabled(false)
+      console.error(e)
+    }
+  }
+
+  // TODO: 仮置き ユーザ登録前に登録キャンセルした場合は認証を消す
+  const deleteAuthHandler = () => {
+    auth.currentUser?.delete()
+    router.push('/')
+  }
 
   return (
-    <>
-      <Header href="/home" title="アカウント作成" />
-      <ButtonFill onClick={() => router.push('/home')}>
-        アカウント作成
-      </ButtonFill>
-    </>
+    <div>
+      {!currentUserUid ? (
+        <p>ログインに失敗しました。大変お手数ですが、再度お試しください</p>
+      ) : (
+        <>
+          <Header title="アカウント作成" />
+          <ButtonFill
+            disabled={disabled}
+            onClick={async () => {
+              await onCreateUserHandler()
+              router.push('/home')
+            }}
+          >
+            アカウント作成
+          </ButtonFill>
+          <button onClick={deleteAuthHandler}>アカウント作成を中断する</button>
+        </>
+      )}
+    </div>
   )
 }
 

--- a/front/src/redux/actions/clearAll.ts
+++ b/front/src/redux/actions/clearAll.ts
@@ -1,0 +1,4 @@
+import { createAction } from '@reduxjs/toolkit'
+
+export const ALL_CLEAR = 'all/clear'
+export const clearAll = createAction<void>(ALL_CLEAR)

--- a/front/src/redux/actions/index.ts
+++ b/front/src/redux/actions/index.ts
@@ -1,0 +1,1 @@
+export { ALL_CLEAR, clearAll } from '@/redux/actions/clearAll'

--- a/front/src/redux/rootStore.ts
+++ b/front/src/redux/rootStore.ts
@@ -1,17 +1,19 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { setupListeners } from '@reduxjs/toolkit/dist/query'
 import { baseFirestoreApi } from '@/redux/services/firestore/baseFirestoreApi'
-import { authReducer, mapReducer } from '@/redux/stores'
+import { authReducer, mapReducer, currentUserReducers } from '@/redux/stores'
 
-export type StateType = ReturnType<typeof store.getState>
-export type DispatchType = typeof store.dispatch
+export type RootState = ReturnType<typeof rootReducer>
+export type AppDispatch = typeof store.dispatch
 
-export const useAppDispath = () => useDispatch<DispatchType>()
-export const useAppSelector: TypedUseSelectorHook<StateType> = useSelector
+export const useAppDispath = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 
 const rootReducer = combineReducers({
   auth: authReducer,
   map: mapReducer,
+  user: currentUserReducers,
   [baseFirestoreApi.reducerPath]: baseFirestoreApi.reducer
 })
 
@@ -20,5 +22,10 @@ export const store = configureStore({
     return rootReducer(state, action)
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(baseFirestoreApi.middleware)
+    getDefaultMiddleware({
+      // TODO: createdAtを直した時に直す
+      serializableCheck: false
+    }).concat(baseFirestoreApi.middleware)
 })
+
+setupListeners(store.dispatch)

--- a/front/src/redux/rootStore.ts
+++ b/front/src/redux/rootStore.ts
@@ -1,6 +1,7 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { setupListeners } from '@reduxjs/toolkit/dist/query'
+import { ALL_CLEAR } from '@/redux/actions'
 import { baseFirestoreApi } from '@/redux/services/firestore/baseFirestoreApi'
 import { authReducer, mapReducer, currentUserReducers } from '@/redux/stores'
 
@@ -19,6 +20,10 @@ const rootReducer = combineReducers({
 
 export const store = configureStore({
   reducer: (state, action) => {
+    // ALL_CLEARアクションが呼ばれたらステートを全部消す
+    if (action.type === ALL_CLEAR) {
+      return rootReducer(undefined, action)
+    }
     return rootReducer(state, action)
   },
   middleware: (getDefaultMiddleware) =>

--- a/front/src/redux/services/firestore/baseFirestoreApi.ts
+++ b/front/src/redux/services/firestore/baseFirestoreApi.ts
@@ -4,6 +4,6 @@ import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
 export const baseFirestoreApi = createApi({
   reducerPath: 'baseFirestoreApi',
   baseQuery: fakeBaseQuery(),
-  tagTypes: [],
+  tagTypes: ['User'],
   endpoints: () => ({})
 })

--- a/front/src/redux/services/firestore/index.ts
+++ b/front/src/redux/services/firestore/index.ts
@@ -1,1 +1,7 @@
-export {}
+// users
+export {
+  usersApi,
+  useGetUserQuery,
+  useCreateUserMutation,
+  type UserType
+} from '@/redux/services/firestore/users/users'

--- a/front/src/redux/services/firestore/users/users.ts
+++ b/front/src/redux/services/firestore/users/users.ts
@@ -40,32 +40,34 @@ export const usersApi = baseFirestoreApi.injectEndpoints({
           ) as DocumentReference<UserType>
 
           const snapshot = await getDoc(ref)
-          
+
           const isUserExists = snapshot.exists()
           if (!isUserExists) return { data: null }
-            
+
           const user = snapshot.data()
           return { data: user }
         } catch (error) {
           return { error }
         }
-      }
+      },
+      providesTags: ['User']
     }),
-    createUser: builder.mutation<void, CreateUserType>({
+    createUser: builder.mutation<string, CreateUserType>({
       queryFn: async ({ id, body }) => {
         try {
-          const res = await setDoc(doc(db, 'users', id), {
+          await setDoc(doc(db, 'users', id), {
             ...body,
             createdAt: serverTimestamp()
           })
 
           return {
-            data: res
+            data: 'OK'
           }
         } catch (error) {
           return { error }
         }
-      }
+      },
+      invalidatesTags: (_result, error) => (error ? [] : ['User'])
     })
   }),
   overrideExisting: false

--- a/front/src/redux/services/firestore/users/users.ts
+++ b/front/src/redux/services/firestore/users/users.ts
@@ -1,0 +1,74 @@
+import {
+  DocumentReference,
+  Timestamp,
+  collection,
+  doc,
+  getDoc,
+  serverTimestamp,
+  setDoc
+} from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { baseFirestoreApi } from '@/redux/services/firestore/baseFirestoreApi'
+
+export type UserType = {
+  email: string
+  icon: string | null
+  name: string
+  userId: string
+  description: string | null
+  links: {
+    instagram: string | null
+    twitter: string | null
+  }
+  createdAt: Timestamp
+  updatedAt: Timestamp | null
+}
+
+type CreateUserType = {
+  id: string
+  body: Omit<UserType, 'createdAt' | 'updatedAt'>
+}
+
+export const usersApi = baseFirestoreApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getUser: builder.query<UserType | null, string>({
+      queryFn: async (uid) => {
+        try {
+          const ref = doc(
+            collection(db, 'users'),
+            uid
+          ) as DocumentReference<UserType>
+
+          const snapshot = await getDoc(ref)
+          
+          const isUserExists = snapshot.exists()
+          if (!isUserExists) return { data: null }
+            
+          const user = snapshot.data()
+          return { data: user }
+        } catch (error) {
+          return { error }
+        }
+      }
+    }),
+    createUser: builder.mutation<void, CreateUserType>({
+      queryFn: async ({ id, body }) => {
+        try {
+          const res = await setDoc(doc(db, 'users', id), {
+            ...body,
+            createdAt: serverTimestamp()
+          })
+
+          return {
+            data: res
+          }
+        } catch (error) {
+          return { error }
+        }
+      }
+    })
+  }),
+  overrideExisting: false
+})
+
+export const { useGetUserQuery, useCreateUserMutation } = usersApi

--- a/front/src/redux/stores/auths/authSlice.ts
+++ b/front/src/redux/stores/auths/authSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, createSelector, PayloadAction } from '@reduxjs/toolkit'
-import { StateType } from '@/redux/rootStore'
+import { RootState } from '@/redux/rootStore'
 
 export type AuthType = {
   uid: string | null
@@ -21,10 +21,10 @@ const authSlice = createSlice({
 
 export const { setUser } = authSlice.actions
 
-const stateSelector = (state: StateType) => state.auth
+const stateSelector = (state: RootState) => state.auth
 
 export const authSelectors = {
-  currentUser: createSelector(stateSelector, (state) => state)
+  currentUserUid: createSelector(stateSelector, (state) => state.uid)
 }
 
 export const authReducer = authSlice.reducer

--- a/front/src/redux/stores/index.ts
+++ b/front/src/redux/stores/index.ts
@@ -13,3 +13,9 @@ export {
   setCenterAddress
 } from '@/redux/stores/maps/mapSlice'
 export type { CenterAddressType } from '@/redux/stores/maps/mapSlice'
+
+// ユーザ情報
+export {
+  currentUserReducers,
+  currentUserSelectors
+} from '@/redux/stores/users/userSlice'

--- a/front/src/redux/stores/maps/mapSlice.ts
+++ b/front/src/redux/stores/maps/mapSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, createSelector, PayloadAction } from '@reduxjs/toolkit'
-import { StateType } from '@/redux/rootStore'
+import { RootState } from '@/redux/rootStore'
 
 export type CenterAddressType = {
   name: string | null
@@ -35,7 +35,7 @@ const mapSlice = createSlice({
 
 export const { setCenterAddress } = mapSlice.actions
 
-const stateSelector = (state: StateType) => state.map
+const stateSelector = (state: RootState) => state.map
 
 export const mapSelectors = {
   currentCenter: createSelector(stateSelector, (state) => state)

--- a/front/src/redux/stores/users/userSlice.ts
+++ b/front/src/redux/stores/users/userSlice.ts
@@ -1,0 +1,42 @@
+import { createSlice, createSelector } from '@reduxjs/toolkit'
+import { RootState } from '@/redux/rootStore'
+import { usersApi } from '@/redux/services/firestore/'
+
+type CurrentUserType = {
+  name: string
+  icon: string | null
+  userId: string
+}
+
+const initialState: CurrentUserType = {
+  name: '',
+  icon: null,
+  userId: ''
+}
+
+const currentUserSlice = createSlice({
+  name: 'currentUser',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addMatcher(
+      usersApi.endpoints.getUser.matchFulfilled,
+      (state, action) => {
+        if (action.payload) {
+          state.icon = action.payload.icon
+          state.userId = action.payload.userId
+          state.name = action.payload.name
+        }
+      }
+    )
+  }
+})
+
+const stateSelector = (state: RootState) => state.user
+
+export const currentUserSelectors = {
+  isRegisteredUser: createSelector(stateSelector, (state) => !!state),
+  currentUserData: createSelector(stateSelector, (state) => state)
+}
+
+export const currentUserReducers = currentUserSlice.reducer

--- a/front/src/redux/stores/users/userSlice.ts
+++ b/front/src/redux/stores/users/userSlice.ts
@@ -35,7 +35,7 @@ const currentUserSlice = createSlice({
 const stateSelector = (state: RootState) => state.user
 
 export const currentUserSelectors = {
-  isRegisteredUser: createSelector(stateSelector, (state) => !!state),
+  isRegisteredUser: createSelector(stateSelector, (state) => !!state.userId),
   currentUserData: createSelector(stateSelector, (state) => state)
 }
 

--- a/front/src/utils/firebase/index.ts
+++ b/front/src/utils/firebase/index.ts
@@ -1,0 +1,1 @@
+export { onAuthStateChanged } from '@/utils/firebase/onAuthStateChanged'

--- a/front/src/utils/firebase/onAuthStateChanged.ts
+++ b/front/src/utils/firebase/onAuthStateChanged.ts
@@ -1,0 +1,17 @@
+import {
+  Auth,
+  User,
+  onAuthStateChanged as onFirebaseAuthStateChanged
+} from 'firebase/auth'
+
+export const onAuthStateChanged = (auth: Auth) => {
+  // firebaseのonAuthStateChangedを同期的に処理できるようにする
+  const promise: Promise<User | null> = new Promise((resolve) => {
+    const unsubscribe = onFirebaseAuthStateChanged(auth, (user) => {
+      resolve(user)
+    })
+    unsubscribe()
+  })
+
+  return promise
+}


### PR DESCRIPTION
## 💫 関連Issues
close #112
close #113 

## 💪🏻 変更したこと
- 認証フロー作成
  - 旧トラベリではポップアップでGoogleログインを実装していたので，ブラウザのpopupブロックが作動してしまうことが多々あった
  - 回避するために，redirectによる認証に変更した
  - 下記の記事と，zennの挙動を参考にした
  - https://zenn.dev/ubie_dev/articles/firebase-auth-hack
- createuserとgetUserの定義
- 登録済みユーザの情報は_appでdbから取得してstore管理
- ログアウト時にstore削除
- seedsデータ修正
  - make seedingしてください

## 👀 認証フロー
ユーザの状態: ログインしているかどうか，登録済みかどうか（dbにname, userId, emailなどが登録されているか）の２つ  

- 基本フロー（未ログインかつユーザ未登録）
  - ログインボタンを押す（firebase auth上で認証済みユーザとして管理）
  - /user/newに遷移（未ログインユーザはURL直打ちでアクセス不可）
    - この時点で，ユーザ作成を中止するボタンを押すと，firebase auth上の認証済みユーザごと削除される
  - ユーザ作成ボタンを押すとDBに登録され，登録済みユーザ扱いになる
- ログイン済みかつ未登録ユーザ（ユーザ作成中にブラウザバックした人）
  - 基本的に未認証ユーザと同じ扱いで，/user/newにURL直打ちでアクセス可能なことだけ違う
- ログイン済みユーザかつ登録済みユーザ
  - ログインボタンを押すと/homeに遷移
  - /user/newにアクセスすると/homeにリダイレクト

## アクセス可能ページ
- 404などのスタティックなページは認証しない
- /home, /triplinkなどの，ユーザ登録済みでないとアクセスできないページは，トップにリダイレクト
- その他，未認証でもアクセス可能なページ（triplateなど）は，都度ページごとに出し分け

## 📸 確認方法
- 新規登録フロー
  - http://localhost:3000/ にアクセス
  - サインインを押す
  - add new accountから，auto generate user informationを押して，サインイン
  - アカウント作成を押すと適当なユーザで登録される（基本はGoogleと一緒，userIdはuidの上4桁）
  - bottomナビゲーションの一番右を押すと自分の名前が表示かつurlが自分のuserIdになっていることを確認できる
- テストユーザでログインを押すと，既にtriplinkを持ったユーザ（シードデータ）としてログインできるので，開発中は主にこっちを使ってください．

## 🙈 self review
- [x] 必要のないCSSはないか（特にサイトからコピペした場合注意）
- [x] The Nu Html Checkerでエラーがでていないこと
